### PR TITLE
preserves post processors for of custom factories

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -460,11 +460,11 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 
 	/**
 	 * This method ensures, that the returned properties map contains a transaction id prefix.
-	 * <P>
+	 * <p>
 	 *     The {@link org.springframework.kafka.core.DefaultKafkaProducerFactory} modifies the local properties copy, the txn key is removed and
 	 *     stored locally in a property. To make a proper copy of the properties in a new factory, the transactionId has to be reinserted prior use.
 	 *     The incoming properties are checked for a transactionId key. If none is there, the one existing in the factory is added.
-	 * </P>
+	 * </p>
 	 * @param producerProperties the properties to be used for the new factory
 	 * @return the producerProperties or a copy with the transaction ID set
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -430,12 +430,16 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	}
 
 	/**
-	 * This method will use the properties of the instance and the given properties to create a new producer factory.
-	 * <p>If the {@link org.springframework.kafka.core.DefaultKafkaProducerFactory} makes a copy of itself, the transaction id prefix is recovered from.
-	 * the properties. If you want to change the ID config, add a new {@link org.apache.kafka.clients.producer.ProducerConfig#TRANSACTIONAL_ID_CONFIG}
+	 * This method will use the properties of the instance and the given properties to
+	 * create a new producer factory.
+	 * <p>If the {@link org.springframework.kafka.core.DefaultKafkaProducerFactory} makes a
+	 * copy of itself, the transaction id prefix is recovered from the properties. If
+	 * you want to change the ID config, add a new
+	 * {@link org.apache.kafka.clients.producer.ProducerConfig#TRANSACTIONAL_ID_CONFIG}
 	 * key to the override config.</p>
 	 * @param overrideProperties the properties to be applied to the new factory
-	 * @return {@link org.springframework.kafka.core.DefaultKafkaProducerFactory} with properties applied
+	 * @return {@link org.springframework.kafka.core.DefaultKafkaProducerFactory} with
+	 *  properties applied
 	 */
 	@Override
 	public ProducerFactory<K, V> copyWithConfigurationOverride(Map<String, Object> overrideProperties) {
@@ -461,9 +465,12 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	/**
 	 * This method ensures, that the returned properties map contains a transaction id prefix.
 	 * <p>
-	 *     The {@link org.springframework.kafka.core.DefaultKafkaProducerFactory} modifies the local properties copy, the txn key is removed and
-	 *     stored locally in a property. To make a proper copy of the properties in a new factory, the transactionId has to be reinserted prior use.
-	 *     The incoming properties are checked for a transactionId key. If none is there, the one existing in the factory is added.
+	 *     The {@link org.springframework.kafka.core.DefaultKafkaProducerFactory}
+	 *      modifies the local properties copy, the txn key is removed and
+	 *     stored locally in a property. To make a proper copy of the properties in a
+	 *      new factory, the transactionId has to be reinserted prior use.
+	 *     The incoming properties are checked for a transactionId key. If none is
+	 *      there, the one existing in the factory is added.
 	 * </p>
 	 * @param producerProperties the properties to be used for the new factory
 	 * @return the producerProperties or a copy with the transaction ID set

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -174,6 +174,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	 * If the configOverrides is not null or empty, a new
 	 * {@link DefaultKafkaProducerFactory} will be created with merged producer properties
 	 * with the overrides being applied after the supplied factory's properties.
+	 * Copy PostProcessors from original factory to keep instrumentation alive.
 	 * @param producerFactory the producer factory.
 	 * @param autoFlush true to flush after each send.
 	 * @param configOverrides producer configuration properties to override.
@@ -195,6 +196,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 			newFactory.setPhysicalCloseTimeout((int) producerFactory.getPhysicalCloseTimeout().getSeconds());
 			newFactory.setProducerPerConsumerPartition(producerFactory.isProducerPerConsumerPartition());
 			newFactory.setProducerPerThread(producerFactory.isProducerPerThread());
+			for(int i=0; i<producerFactory.getPostProcessors().size(); i++) {
+				newFactory.addPostProcessor(producerFactory.getPostProcessors().get(i));
+			}
 			this.producerFactory = newFactory;
 		}
 		else {

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -172,11 +172,15 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	 * to occur immediately, regardless of that setting, or if you wish to block until the
 	 * broker has acknowledged receipt according to the producer's {@code acks} property.
 	 * If the configOverrides is not null or empty, a new
-	 * {@link ProducerFactory} will be created using {@link org.springframework.kafka.core.ProducerFactory#copyWithConfigurationOverride(java.util.Map)}
+	 * {@link ProducerFactory} will be created using
+	 * {@link org.springframework.kafka.core.ProducerFactory#copyWithConfigurationOverride(java.util.Map)}
 	 * The factory shall apply the overrides after the supplied factory's properties.
-	 * The {@link org.springframework.kafka.core.ProducerPostProcessor}s from the original factory are copied over to keep instrumentation alive.
-	 * Registered {@link org.springframework.kafka.core.ProducerFactory.Listener}s are also added to the new factory.
-	 * If the factory implementation does not support the copy operation, a generic copy of the ProducerFactory is created which will be of type
+	 * The {@link org.springframework.kafka.core.ProducerPostProcessor}s from the
+	 * original factory are copied over to keep instrumentation alive.
+	 * Registered {@link org.springframework.kafka.core.ProducerFactory.Listener}s are
+	 * also added to the new factory. If the factory implementation does not support
+	 * the copy operation, a generic copy of the ProducerFactory is created which will
+	 * be of type
 	 * DefaultKafkaProducerFactory.
 	 * @param producerFactory the producer factory.
 	 * @param autoFlush true to flush after each send.
@@ -213,11 +217,13 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	}
 
 	/**
-	 * This method copies a ProducerFactory that misses the implementation of {@link org.springframework.kafka.core.ProducerFactory#copyWithConfigurationOverride(java.util.Map)}.
+	 * This method copies a ProducerFactory that misses the implementation of
+	 * {@link org.springframework.kafka.core.ProducerFactory#copyWithConfigurationOverride(java.util.Map)}.
 	 *
 	 * @param templateFactory the ProducerFactory to copy from
 	 * @param configOverrides new properties to be applied onto the templateFactory properties
-	 * @return a DefaultKafkaProducerFactory configured with configOverrides and all public reachable settings of ProducerFactory
+	 * @return a DefaultKafkaProducerFactory configured with configOverrides and all
+	 * public reachable settings of ProducerFactory
 	 */
 	private DefaultKafkaProducerFactory<K, V> handleNonCopyableProducerFactory(ProducerFactory<K, V> templateFactory, Map<String, Object> configOverrides) {
 		Map<String, Object> producerProperties = new HashMap<>(templateFactory.getConfigurationProperties());

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -172,9 +172,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	 * to occur immediately, regardless of that setting, or if you wish to block until the
 	 * broker has acknowledged receipt according to the producer's {@code acks} property.
 	 * If the configOverrides is not null or empty, a new
-	 * {@link DefaultKafkaProducerFactory} will be created with merged producer properties
-	 * with the overrides being applied after the supplied factory's properties.
-	 * The {@link org.springframework.beans.factory.config.BeanPostProcessor}s from the original factory are copied over to keep instrumentation alive.
+	 * {@link ProducerFactory} will be created using {@link org.springframework.kafka.core.ProducerFactory#copyWithConfigurationOverride(java.util.Map)}
+	 * The factory shall apply the overrides after the supplied factory's properties.
+	 * The {@link org.springframework.kafka.core.ProducerPostProcessor}s from the original factory are copied over to keep instrumentation alive.
 	 * Registered {@link org.springframework.kafka.core.ProducerFactory.Listener}s are also added to the new factory.
 	 * @param producerFactory the producer factory.
 	 * @param autoFlush true to flush after each send.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -18,7 +18,6 @@ package org.springframework.kafka.core;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -273,30 +272,20 @@ public interface ProducerFactory<K, V> {
 		return null;
 	}
 
-
 	/**
 	 * This method will use the properties of the instance and the given properties to create a new producer factory.
-	 * <p>Note: {@see org.springframework.kafka.core.DefaultKafkaProducerFactory#copyWithConfigurationOverride}</p>
+	 * <p>The copy shall prioritize the override properties over the configured values. It is in the responsibility of the factory
+	 * implementation to make sure the configuration of the new factory is identical, complete and correct.</p>
+	 * <p>ProducerPostProcessor and Listeners must stay intact.</p>
+	 * <p>If the factory does not implement this method, an exception will be thrown.</p>
+	 * <p>Note: see {@link org.springframework.kafka.core.DefaultKafkaProducerFactory#copyWithConfigurationOverride}</p>
 	 * @param overrideProperties the properties to be applied to the new factory
 	 * @return {@link org.springframework.kafka.core.ProducerFactory} with properties applied
+	 * @since 2.5.17
+	 * @see org.springframework.kafka.core.KafkaTemplate#KafkaTemplate(ProducerFactory, java.util.Map)
 	 */
 	default ProducerFactory<K, V> copyWithConfigurationOverride(Map<String, Object> overrideProperties) {
-		Map<String, Object> producerProperties = new HashMap<>(this.getConfigurationProperties());
-		producerProperties.putAll(overrideProperties);
-
-		DefaultKafkaProducerFactory<K, V> newFactory = new DefaultKafkaProducerFactory<>(producerProperties,
-				getKeySerializerSupplier(),
-				getValueSerializerSupplier());
-		newFactory.setPhysicalCloseTimeout((int) getPhysicalCloseTimeout().getSeconds());
-		newFactory.setProducerPerConsumerPartition(isProducerPerConsumerPartition());
-		newFactory.setProducerPerThread(isProducerPerThread());
-		for (ProducerPostProcessor<K, V> templatePostProcessor : getPostProcessors()) {
-			newFactory.addPostProcessor(templatePostProcessor);
-		}
-		for (ProducerFactory.Listener<K, V> templateListener : getListeners()) {
-			newFactory.addListener(templateListener);
-		}
-		return newFactory;
+		throw new UnsupportedOperationException("This factory implementation doesn't support creating reconfigured copies.");
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -273,14 +273,18 @@ public interface ProducerFactory<K, V> {
 	}
 
 	/**
-	 * This method will use the properties of the instance and the given properties to create a new producer factory.
-	 * <p>The copy shall prioritize the override properties over the configured values. It is in the responsibility of the factory
-	 * implementation to make sure the configuration of the new factory is identical, complete and correct.</p>
+	 * This method will use the properties of the instance and the given properties to
+	 * create a new producer factory.
+	 * <p>The copy shall prioritize the override properties over the configured values.
+	 * It is in the responsibility of the factory implementation to make sure the
+	 * configuration of the new factory is identical, complete and correct.</p>
 	 * <p>ProducerPostProcessor and Listeners must stay intact.</p>
 	 * <p>If the factory does not implement this method, an exception will be thrown.</p>
-	 * <p>Note: see {@link org.springframework.kafka.core.DefaultKafkaProducerFactory#copyWithConfigurationOverride}</p>
+	 * <p>Note: see
+	 * {@link org.springframework.kafka.core.DefaultKafkaProducerFactory#copyWithConfigurationOverride}</p>
 	 * @param overrideProperties the properties to be applied to the new factory
-	 * @return {@link org.springframework.kafka.core.ProducerFactory} with properties applied
+	 * @return {@link org.springframework.kafka.core.ProducerFactory} with properties
+	 * applied
 	 * @since 2.5.17
 	 * @see org.springframework.kafka.core.KafkaTemplate#KafkaTemplate(ProducerFactory, java.util.Map)
 	 */

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -468,7 +468,6 @@ public class KafkaTemplateTests {
 		pf.destroy();
 	}
 
-	// TODO this test runs mainly through DefaultKafkaProducerFactory and should be tested there as well
 	@Test
 	void testConfigOverrides() {
 		ProducerFactory.Listener<String, String> noopListener = new ProducerFactory.Listener<>() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -468,6 +468,7 @@ public class KafkaTemplateTests {
 		pf.destroy();
 	}
 
+	// TODO this test runs mainly through DefaultKafkaProducerFactory and should be tested there as well
 	@Test
 	void testConfigOverrides() {
 		ProducerFactory.Listener<String, String> noopListener = new ProducerFactory.Listener<>() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -31,6 +31,7 @@ import static org.springframework.kafka.test.assertj.KafkaConditions.value;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -469,21 +470,54 @@ public class KafkaTemplateTests {
 
 	@Test
 	void testConfigOverrides() {
+		ProducerFactory.Listener<String, String> noopListener = new ProducerFactory.Listener<>() {
+
+			@Override
+			public void producerAdded(String id, Producer<String, String> producer) {
+			}
+
+			@Override
+			public void producerRemoved(String id, Producer<String, String> producer) {
+			}
+
+		};
+		ProducerPostProcessor<String, String> noopProducerPostProcessor = processor -> processor;
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
 		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setPhysicalCloseTimeout(6);
 		pf.setProducerPerConsumerPartition(false);
 		pf.setProducerPerThread(true);
+		pf.addPostProcessor(noopProducerPostProcessor);
+		pf.addListener(noopListener);
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 		overrides.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "TX");
 		KafkaTemplate<String, String> template = new KafkaTemplate<>(pf, true, overrides);
+		// modify the overrides map TXNid and clone it again
+		overrides.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "TX2");
+		KafkaTemplate<String, String> templateWTX2 = new KafkaTemplate<>(template.getProducerFactory(), true, overrides);
+		// clone the factory again with empty properties
+		KafkaTemplate<String, String> templateWTX2_2 = new KafkaTemplate<>(templateWTX2.getProducerFactory(), true,
+				Collections.singletonMap("dummy", "dont use"));
 		assertThat(template.getProducerFactory().getConfigurationProperties()
 				.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)).isEqualTo(StringSerializer.class);
 		assertThat(template.getProducerFactory().getPhysicalCloseTimeout()).isEqualTo(Duration.ofSeconds(6));
 		assertThat(template.getProducerFactory().isProducerPerConsumerPartition()).isFalse();
 		assertThat(template.getProducerFactory().isProducerPerThread()).isTrue();
 		assertThat(template.isTransactional()).isTrue();
+		assertThat(template.getProducerFactory().getListeners()).isEqualTo(pf.getListeners());
+		assertThat(template.getProducerFactory().getListeners().size()).isEqualTo(1);
+		assertThat(template.getProducerFactory().getPostProcessors()).isEqualTo(pf.getPostProcessors());
+		assertThat(template.getProducerFactory().getPostProcessors().size()).isEqualTo(1);
+
+		// then: initially we created without TX
+		assertThat(pf.getTransactionIdPrefix()).isBlank();
+		// and: we added TX to the first copy factory
+		assertThat(template.getProducerFactory().getTransactionIdPrefix()).isEqualTo("TX");
+		// and: we modified TX to TX2 in the second copy factory
+		assertThat(templateWTX2.getProducerFactory().getTransactionIdPrefix()).isEqualTo("TX2");
+		// and: we reuse the id from the template (TX2) in the third copy factory
+		assertThat(templateWTX2_2.getProducerFactory().getTransactionIdPrefix()).isEqualTo("TX2");
 	}
 
 	@Test


### PR DESCRIPTION
instrumentations attached to ProducerFactory instances are destroyed if the user adds configOverrides. This behavior is unexpected for the developer, for example it will undo sleuth instrumentation that is otherwise kept if the new KafkaTemplate(Map) constructor would be used.